### PR TITLE
networkd: bond - only set packets_per_slave on balance-rr mode

### DIFF
--- a/src/network/networkd-netdev-bond.c
+++ b/src/network/networkd-netdev-bond.c
@@ -273,7 +273,7 @@ static int netdev_bond_fill_message_create(NetDev *netdev, Link *link, sd_rtnl_m
         }
 
         if (b->ad_select != _NETDEV_BOND_AD_SELECT_INVALID &&
-            b->mode == BOND_MODE_8023AD) {
+            b->mode == NETDEV_BOND_MODE_802_3AD) {
                 r = sd_rtnl_message_append_u8(m, IFLA_BOND_AD_SELECT, b->ad_select);
                 if (r < 0) {
                         log_netdev_error(netdev,
@@ -334,7 +334,8 @@ static int netdev_bond_fill_message_create(NetDev *netdev, Link *link, sd_rtnl_m
                 }
         }
 
-        if (b->packets_per_slave <= PACKETS_PER_SLAVE_MAX) {
+        if (b->packets_per_slave <= PACKETS_PER_SLAVE_MAX &&
+            b->mode == NETDEV_BOND_MODE_BALANCE_RR) {
                 r = sd_rtnl_message_append_u32(m, IFLA_BOND_PACKETS_PER_SLAVE, b->packets_per_slave);
                 if (r < 0) {
                         log_netdev_error(netdev,


### PR DESCRIPTION
Otherwise the creation of the bond fails.

Required for https://github.com/coreos/coreos-overlay/pull/1282
