### PR TITLE
escape: fix exit code

### DIFF
--- a/src/escape/escape.c
+++ b/src/escape/escape.c
@@ -236,5 +236,5 @@ int main(int argc, char *argv[]) {
         fputc('\n', stdout);
 
 finish:
-        return r <= 0 ? EXIT_FAILURE : EXIT_SUCCESS;
+        return r < 0 ? EXIT_FAILURE : EXIT_SUCCESS;
 }


### PR DESCRIPTION
r == 0 indicates success, not failure
