### PR TITLE
util: fix another cunescape() regression

### DIFF
--- a/src/shared/util.c
+++ b/src/shared/util.c
@@ -1186,7 +1186,7 @@ static int cunescape_one(const char *p, size_t length, char *ret, uint32_t *ret_
                 int a, b, c;
                 uint32_t m;
 
-                if (length != (size_t) -1 && length < 4)
+                if (length != (size_t) -1 && length < 3)
                         return -EINVAL;
 
                 a = unoctchar(p[0]);

--- a/src/test/test-util.c
+++ b/src/test/test-util.c
@@ -459,6 +459,9 @@ static void test_cunescape(void) {
         assert_se(cunescape("\\u0000", 0, &unescaped) < 0);
         assert_se(cunescape("\\u00DF\\U000000df\\u03a0\\U00000041", UNESCAPE_RELAX, &unescaped) >= 0);
         assert_se(streq_ptr(unescaped, "ßßΠA"));
+
+        assert_se(cunescape("\\073", 0, &unescaped) >= 0);
+        assert_se(streq_ptr(unescaped, ";"));
 }
 
 static void test_foreach_word(void) {


### PR DESCRIPTION
Cherry-picking ea344aec104771c11b2008e54943d7c108ecb0d0 to fix https://github.com/coreos/bugs/issues/387.
