### PR TITLE
load-fragment: use UNESCAPE_RELAX flag to parse exec directives

### DIFF
--- a/src/core/load-fragment.c
+++ b/src/core/load-fragment.c
@@ -609,7 +609,7 @@ int config_parse_exec(
                         else
                                 skip = strneq(word, "\\;", MAX(l, 1U));
 
-                        r = cunescape_length(word + skip, l - skip, 0, &c);
+                        r = cunescape_length(word + skip, l - skip, UNESCAPE_RELAX, &c);
                         if (r < 0) {
                                 log_syntax(unit, LOG_ERR, filename, line, r, "Failed to unescape command line, ignoring: %s", rvalue);
                                 r = 0;


### PR DESCRIPTION
Cherry-picking 22874a348fb1540c1a2b7907748fc57c9756a7ed to fix https://github.com/coreos/bugs/issues/405.
