### PR TITLE
sd-dhcp-lease: fix handling of multiple routers

### DIFF
--- a/src/libsystemd-network/sd-dhcp-lease.c
+++ b/src/libsystemd-network/sd-dhcp-lease.c
@@ -435,7 +435,8 @@ int dhcp_lease_parse_options(uint8_t code, uint8_t len, const uint8_t *option,
                 break;
 
         case DHCP_OPTION_ROUTER:
-                lease_parse_be32(option, len, &lease->router);
+                if(len >= 4)
+                        lease_parse_be32(option, 4, &lease->router);
 
                 break;
 


### PR DESCRIPTION
currently if a dhcp server sends more than one router, sd-dhcp-lease
does not copy the ip because it assumes it will only ever be 4 bytes. a
dhcp server could send more than one ip in the router list, so we should
copy the first one and ignore the rest of the bytes.
