### PR TITLE
journal-gatewayd: fix tmpfile logic

### DIFF
--- a/src/journal-remote/journal-gatewayd.c
+++ b/src/journal-remote/journal-gatewayd.c
@@ -132,7 +132,7 @@ static int request_meta_ensure_tmp(RequestMeta *m) {
                 if (fd < 0)
                         return fd;
 
-                m->tmp = fdopen(fd, "rw");
+                m->tmp = fdopen(fd, "w+");
                 if (!m->tmp) {
                         safe_close(fd);
                         return -errno;


### PR DESCRIPTION
"rw" is not a valid mode string for f*open(). This got broken in
cc02a7b33049 ("journal-gatewayd: factor out opening of temp
file").

cherry-picked 9e19c04f3a4e03e37dc89b63c1ae9b0a7c611810 from upstream pull request systemd/systemd#510.

fixes coreos/bugs#408.
