### PR TITLE
journal: return 0 from compress_blob() on errors

### DIFF
--- a/src/journal/compress.h
+++ b/src/journal/compress.h
@@ -42,7 +42,7 @@ static inline int compress_blob(const void *src, uint64_t src_size, void *dst, s
         if (r == 0)
                 return OBJECT_COMPRESSED_XZ;
 #endif
-        return r;
+        return 0;
 }
 
 int decompress_blob_xz(const void *src, uint64_t src_size,


### PR DESCRIPTION
The one and only caller in journal-file.c treats non-zero as success:

```
compression = compress_blob(data, size, o->data.payload, &rsize);

if (compression) {
        assert(rsize);

        o->object.size = htole64(offsetof(Object, data.payload) + rsize);
        o->object.flags |= compression;

        log_debug("Compressed data object %"PRIu64" -> %zu using %s",
                  size, rsize, object_compressed_to_string(compression));
}
```

This fixes a bug observed when the src was 512 bytes in length.  The
resulting rsize would be 0 because XZ compression failed, but the code
continued as if successful because the non-zero XZ error return value
was percolating out of compress_blob().
