### PR TITLE
Revert "sd-bus: do not connect to dbus-1 socket when kdbus is available"

### DIFF
--- a/src/libsystemd/sd-bus/sd-bus.c
+++ b/src/libsystemd/sd-bus/sd-bus.c
@@ -1002,8 +1002,6 @@ static int bus_parse_next_address(sd_bus *b) {
 }
 
 static int bus_start_address(sd_bus *b) {
-        bool container_kdbus_available = false;
-        bool kdbus_available = false;
         int r;
 
         assert(b);
@@ -1013,29 +1011,15 @@ static int bus_start_address(sd_bus *b) {
 
                 bus_close_fds(b);
 
-                /*
-                 * Usually, if you provide multiple different bus-addresses, we
-                 * try all of them in order. We use the first one that
-                 * succeeds. However, if you mix kernel and unix addresses, we
-                 * never try unix-addresses if a previous kernel address was
-                 * tried and kdbus was available. This is required to prevent
-                 * clients to fallback to the bus-proxy if kdbus is available
-                 * but failed (eg., too many connections).
-                 */
-
                 if (b->exec_path)
                         r = bus_socket_exec(b);
-                else if ((b->nspid > 0 || b->machine) && b->kernel) {
+                else if ((b->nspid > 0 || b->machine) && b->kernel)
                         r = bus_container_connect_kernel(b);
-                        if (r < 0 && !IN_SET(r, -ENOENT, -ESOCKTNOSUPPORT))
-                                container_kdbus_available = true;
-                } else if (!container_kdbus_available && (b->nspid > 0 || b->machine) && b->sockaddr.sa.sa_family != AF_UNSPEC)
+                else if ((b->nspid > 0 || b->machine) && b->sockaddr.sa.sa_family != AF_UNSPEC)
                         r = bus_container_connect_socket(b);
-                else if (b->kernel) {
+                else if (b->kernel)
                         r = bus_kernel_connect(b);
-                        if (r < 0 && !IN_SET(r, -ENOENT, -ESOCKTNOSUPPORT))
-                                kdbus_available = true;
-                } else if (!kdbus_available && b->sockaddr.sa.sa_family != AF_UNSPEC)
+                else if (b->sockaddr.sa.sa_family != AF_UNSPEC)
                         r = bus_socket_connect(b);
                 else
                         skipped = true;


### PR DESCRIPTION
This reverts commit 154429127cb400bf010d41d7dd3ba4ec41b9ffb3.

The patch this reverts has flawed logic which ended up being fixed by https://github.com/systemd/systemd/commit/751090cc8ae09787402d60b7080d479b3afe3b13. Both patches depend on `bus_container_connect_kernel()` returning specific error codes (e.g. `-ENOENT` or `-ESOCKTNOSUPPORT`), but oddly enough, that functionality didn't exist until https://github.com/systemd/systemd/commit/80b0d3e3116f85cab8b19caf1cfa9d56be190a2e ([here](https://github.com/systemd/systemd/commit/80b0d3e3116f85cab8b19caf1cfa9d56be190a2e#diff-169c785ff57416418587b15fbe9aaea9R191) and [here](https://github.com/systemd/systemd/commit/80b0d3e3116f85cab8b19caf1cfa9d56be190a2e#diff-169c785ff57416418587b15fbe9aaea9R257)). Rather than backporting all of _those_ changes (and probably breaking more stuff), use the previous behavior and allow sd-bus to fall back from a kernel connection to a unix socket.

Fixes https://github.com/coreos/bugs/issues/1002.
