### PR TITLE
networkd: unlink link state file when freeing a link

### DIFF
--- a/src/network/networkd-link.c
+++ b/src/network/networkd-link.c
@@ -315,6 +315,8 @@ static void link_free(Link *link) {
         if (link->manager)
                 hashmap_remove(link->manager->links, INT_TO_PTR(link->ifindex));
 
+        (void) unlink(link->state_file);
+
         free(link->ifname);
 
         free(link->state_file);


### PR DESCRIPTION
backporting patch for coreos/bugs#1081
