### PR TITLE
Revert "networkd: unlink link state file when freeing a link"

### DIFF
--- a/src/network/networkd-link.c
+++ b/src/network/networkd-link.c
@@ -315,8 +315,6 @@ static void link_free(Link *link) {
         if (link->manager)
                 hashmap_remove(link->manager->links, INT_TO_PTR(link->ifindex));
 
-        (void) unlink(link->state_file);
-
         free(link->ifname);
 
         free(link->state_file);


### PR DESCRIPTION
This reverts commit 641481fbad7e66ac8d9bda8d3454e837f452495a.
