### PR TITLE
/dev/console must be labeled with SELinux label

### DIFF
--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -87,6 +87,7 @@
 #ifdef HAVE_SECCOMP
 #include "seccomp-util.h"
 #endif
+#include "selinux-util.h"
 #include "signal-util.h"
 #include "socket-util.h"
 #include "stat-util.h"
@@ -3284,6 +3285,12 @@ int main(int argc, char *argv[]) {
         if (r < 0) {
                 r = log_error_errno(r, "Failed to determine tty name: %m");
                 goto finish;
+        }
+
+        if (arg_selinux_apifs_context) {
+                r = mac_selinux_apply(console, arg_selinux_apifs_context);
+                if (r < 0)
+                        goto finish;
         }
 
         if (unlockpt(master) < 0) {


### PR DESCRIPTION
If the user specifies an selinux_apifs_context all content created in
the container including /dev/console should use this label.

Currently when this uses the default label it gets labeled user_devpts_t,
which would require us to write a policy allowing container processes to
manage user_devpts_t.  This means that an escaped process would be allowed
to attack all users terminals as well as other container terminals.  Changing
the label to match the apifs_context, means the processes would only be allowed
to manage their specific tty.

This change fixes a problem preventing RKT containers from working with systemd-nspawn.
