### PR TITLE
networkd: fix systemd-networkd-wait-online with multiple NICs

### DIFF
--- a/src/network/networkd-wait-online-manager.c
+++ b/src/network/networkd-wait-online-manager.c
@@ -77,13 +77,13 @@ bool manager_all_configured(Manager *m) {
                 if (!l->state) {
                         log_debug("link %s has not yet been processed by udev",
                                   l->ifname);
-                        return false;
+                        continue;
                 }
 
                 if (STR_IN_SET(l->state, "configuring", "pending")) {
                         log_debug("link %s is being processed by networkd",
                                   l->ifname);
-                        return false;
+                        continue;
                 }
 
                 if (l->operational_state &&


### PR DESCRIPTION
when checking interface status, systemd-networkd-wait-online
will continue to wait if any interface is still configuring or
being processed by udev. this patch allows it to return if any
one interface is degraded/routable, as per the manual.
