### PR TITLE
needs-update: don't require strictly newer usr

### DIFF
--- a/man/systemd-update-done.service.xml
+++ b/man/systemd-update-done.service.xml
@@ -75,7 +75,7 @@
     <varname>ConditionNeedsUpdate=</varname> (see
     <citerefentry><refentrytitle>systemd.unit</refentrytitle><manvolnum>5</manvolnum></citerefentry>)
     condition to make sure to run when <filename>/etc</filename> or
-    <filename>/var</filename> are older than <filename>/usr</filename>
+    <filename>/var</filename> aren't the same age as <filename>/usr</filename>
     according to the modification times of the files described above.
     This requires that updates to <filename>/usr</filename> are always
     followed by an update of the modification time of

--- a/man/systemd.unit.xml
+++ b/man/systemd.unit.xml
@@ -961,7 +961,7 @@
         inverting the condition). This condition may be used to
         conditionalize units on whether the specified directory
         requires an update because <filename>/usr</filename>'s
-        modification time is newer than the stamp file
+        modification time differs from that of the stamp file
         <filename>.updated</filename> in the specified directory. This
         is useful to implement offline updates of the vendor operating
         system resources in <filename>/usr</filename> that require

--- a/src/shared/condition.c
+++ b/src/shared/condition.c
@@ -308,8 +308,8 @@ static int condition_test_needs_update(Condition *c) {
         if (lstat("/usr/", &usr) < 0)
                 return true;
 
-        return usr.st_mtim.tv_sec > other.st_mtim.tv_sec ||
-                (usr.st_mtim.tv_sec == other.st_mtim.tv_sec && usr.st_mtim.tv_nsec > other.st_mtim.tv_nsec);
+        return usr.st_mtim.tv_sec != other.st_mtim.tv_sec ||
+                (usr.st_mtim.tv_sec == other.st_mtim.tv_sec && usr.st_mtim.tv_nsec != other.st_mtim.tv_nsec);
 }
 
 static int condition_test_first_boot(Condition *c) {

--- a/src/update-done/update-done.c
+++ b/src/update-done/update-done.c
@@ -38,7 +38,7 @@ static int apply_timestamp(const char *path, struct timespec *ts) {
         assert(ts);
 
         if (stat(path, &st) >= 0) {
-                /* Is the timestamp file already newer than the OS? If
+                /* Is the timestamp's mtim different from the OS's? If
                  * so, there's nothing to do. We ignore the nanosecond
                  * component of the timestamp, since some file systems
                  * do not support any better accuracy than 1s and we
@@ -46,7 +46,7 @@ static int apply_timestamp(const char *path, struct timespec *ts) {
                  * available. Most notably ext4 on small disks (where
                  * 128 byte inodes are used) does not support better
                  * accuracy than 1s. */
-                if (st.st_mtim.tv_sec > ts->tv_sec)
+                if (st.st_mtim.tv_sec == ts->tv_sec)
                         return 0;
 
                 /* It is older? Then let's update it */


### PR DESCRIPTION
Updates should be triggered whenever usr changes, not only when it is newer.
