### PR TITLE
networkd: make sure we remove udev fd from epoll *before* closing it

### DIFF
--- a/src/libsystemd/sd-event/sd-event.c
+++ b/src/libsystemd/sd-event/sd-event.c
@@ -481,7 +481,8 @@ static void source_io_unregister(sd_event_source *s) {
                 return;
 
         r = epoll_ctl(s->event->epoll_fd, EPOLL_CTL_DEL, s->io.fd, NULL);
-        assert_log(r >= 0);
+        if (r < 0)
+                log_debug_errno(errno, "Failed to remove source %s from epoll: %m", strna(s->description));
 
         s->io.registered = false;
 }

--- a/src/network/networkd-manager.c
+++ b/src/network/networkd-manager.c
@@ -476,13 +476,13 @@ void manager_free(Manager *m) {
 
         free(m->state_file);
 
+        sd_event_source_unref(m->udev_event_source);
         udev_monitor_unref(m->udev_monitor);
         udev_unref(m->udev);
+
         sd_bus_unref(m->bus);
         sd_bus_slot_unref(m->prepare_for_sleep_slot);
-        sd_event_source_unref(m->udev_event_source);
         sd_event_source_unref(m->bus_retry_event_source);
-        sd_event_unref(m->event);
 
         while ((link = hashmap_first(m->links)))
                 link_unref(link);
@@ -501,6 +501,7 @@ void manager_free(Manager *m) {
                 address_pool_free(pool);
 
         sd_netlink_unref(m->rtnl);
+        sd_event_unref(m->event);
 
         free(m);
 }


### PR DESCRIPTION
Proposed fix for https://github.com/coreos/bugs/issues/1197. I haven't been able to repro this failure reliably, but I am reasonably sure this is the root cause.
