### PR TITLE
nspawn: don't try to resolve passed binary before entering namespace

### DIFF
--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -4658,10 +4658,9 @@ int main(int argc, char *argv[]) {
                 } else {
                         const char *p;
 
-                        p = strjoina(arg_directory,
-                                       argc > optind && path_is_absolute(argv[optind]) ? argv[optind] : "/usr/bin/");
-                        if (access(p, F_OK) < 0) {
-                                log_error("Directory %s lacks the binary to execute or doesn't look like a binary tree. Refusing.", arg_directory);
+                        p = strjoina(arg_directory, "/usr/");
+                        if (laccess(p, F_OK) < 0) {
+                                log_error("Directory %s doesn't look like it has an OS tree. Refusing.", arg_directory);
                                 r = -EINVAL;
                                 goto finish;
                         }


### PR DESCRIPTION
Fixes https://github.com/coreos/bugs/issues/1196.
