### PR TITLE
core: always read /proc/self/mountinfo, never /etc/mtab

### DIFF
--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -1503,7 +1503,7 @@ static int mount_load_proc_self_mountinfo(Manager *m, bool set_flags) {
         if (!i)
                 return log_oom();
 
-        r = mnt_table_parse_mtab(t, NULL);
+        r = mnt_table_parse_mtab(t, "/proc/self/mountinfo");
         if (r < 0)
                 return log_error_errno(r, "Failed to parse /proc/self/mountinfo: %m");
 


### PR DESCRIPTION
Passing NULL for the filename to mnt_table_parse_mtab allows libmount to
pick either /etc/mtab or /proc/self/mountinfo depending on whether
/etc/mtab is a regular file or not. Normally it is a symlink but when
booting with an empty /etc the symlink won't be created until tmpfiles
runs. Combined with 6f20f850f79 which re-enables writing to /etc/mtab we
now have systemd reading an incomplete mount table until tmpfiles runs.

Whether or not this is a problem is inherently racy but can cause mount
units to be marked as dead. Later if the unit is activated it may fail.
CoreOS has hit this bug a couple times over with usr.mount.

Relatedly, util-linux introduced the --enable-libmount-force-mountinfo
configure option as an alternative work-around for this sort of
situation. Considering that option is not enabled by default and systemd
should never read /etc/mtab regardless of util-linux's build config we
may as well fix the bug here too. :)
