### PR TITLE
Fix creating transient units with dependencies

### DIFF
--- a/src/core/dbus-manager.c
+++ b/src/core/dbus-manager.c
@@ -683,6 +683,7 @@ static int transient_unit_from_message(
                 return r;
 
         /* Now load the missing bits of the unit we just created */
+        unit_add_to_load_queue(u);
         manager_dispatch_load_queue(m);
 
         *unit = u;

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -3460,7 +3460,6 @@ int unit_make_transient(Unit *u) {
 
         unit_add_to_dbus_queue(u);
         unit_add_to_gc_queue(u);
-        unit_add_to_load_queue(u);
 
         return 0;
 }


### PR DESCRIPTION
This fixes coreos/bugs#1430.
