### PR TITLE
journal: implicitly flush to var on recovery (#4028)

### DIFF
--- a/src/journal/journald-server.c
+++ b/src/journal/journald-server.c
@@ -268,13 +268,14 @@ static int open_journal(
 }
 
 static int system_journal_open(Server *s, bool flush_requested) {
+        bool flushed = false;
         const char *fn;
         int r = 0;
 
         if (!s->system_journal &&
             (s->storage == STORAGE_PERSISTENT || s->storage == STORAGE_AUTO) &&
             (flush_requested
-             || access("/run/systemd/journal/flushed", F_OK) >= 0)) {
+             || (flushed = (access("/run/systemd/journal/flushed", F_OK) >= 0)))) {
 
                 /* If in auto mode: first try to create the machine
                  * path, but not the prefix.
@@ -299,6 +300,16 @@ static int system_journal_open(Server *s, bool flush_requested) {
 
                         r = 0;
                 }
+
+                /* If the runtime journal is open, and we're post-flush, we're
+                 * recovering from a failed system journal rotate (ENOSPC)
+                 * for which the runtime journal was reopened.
+                 *
+                 * Perform an implicit flush to var, leaving the runtime
+                 * journal closed, now that the system journal is back.
+                 */
+                if (s->runtime_journal && flushed)
+                        (void) server_flush_to_var(s);
         }
 
         if (!s->runtime_journal &&
@@ -1296,7 +1307,7 @@ static int dispatch_sigusr1(sd_event_source *es, const struct signalfd_siginfo *
 
         log_info("Received request to flush runtime journal from PID " PID_FMT, si->ssi_pid);
 
-        server_flush_to_var(s);
+        (void) server_flush_to_var(s);
         server_sync(s);
         server_vacuum(s, false, false);
 


### PR DESCRIPTION
When the system journal becomes re-opened post-flush with the runtime
journal open, it implies we've recovered from something like an ENOSPC
situation where the system journal rotate had failed, leaving the system
journal closed, causing the runtime journal to be opened post-flush.

For the duration of the unavailable system journal, we log to the
runtime journal.  But when the system journal gets opened (space made
available, for example), we need to close the runtime journal before new
journal writes will go to the system journal.  Calling
server_flush_to_var() after opening the system journal with a runtime
journal present, post-flush, achieves this while preserving the runtime
journal's contents in the system journal.

The combination of the present flushed flag file and the runtime journal
being open is a state where we should be logging to the system journal,
so it's appropriate to resume doing so once we've successfully opened
the system journal.
