### PR TITLE
Install: correctly report symlink creations

### DIFF
--- a/src/shared/install.c
+++ b/src/shared/install.c
@@ -294,7 +294,7 @@ static int create_symlink(
 
         if (symlink(old_path, new_path) >= 0) {
                 unit_file_changes_add(changes, n_changes, UNIT_FILE_SYMLINK, new_path, old_path);
-                return 0;
+                return 1;
         }
 
         if (errno != EEXIST)
@@ -317,7 +317,7 @@ static int create_symlink(
         unit_file_changes_add(changes, n_changes, UNIT_FILE_UNLINK, new_path, NULL);
         unit_file_changes_add(changes, n_changes, UNIT_FILE_SYMLINK, new_path, old_path);
 
-        return 0;
+        return 1;
 }
 
 static int mark_symlink_for_removal(


### PR DESCRIPTION
All callers of create_symlink(), such as install_info_symlink_wants(), expect
that to return > 0 if it actually did something, and then return that number.
unit_file_enable() uses that to determine if any action was done
(carries_install_info != 0) and if not, show a "The unit files have no
[Install] section" warning.

Return 1 instead of 0 in the two code paths of create_symlink() when the link
was created or replaced with a new value.

This fixes getting a bogus "No [Install] section" warning when enabling a unit
with full path, like "systemctl enable /some/path/myunit.service".
