### PR TITLE
resolved: do not start the DNS stub resolver

### DIFF
--- a/src/resolve/resolved-manager.c
+++ b/src/resolve/resolved-manager.c
@@ -558,10 +558,6 @@ int manager_start(Manager *m) {
 
         assert(m);
 
-        r = manager_dns_stub_start(m);
-        if (r < 0)
-                return r;
-
         r = manager_llmnr_start(m);
         if (r < 0)
                 return r;


### PR DESCRIPTION
This is a temporary fix to restore pre-v231 behavior until upstream accepts a configurable way to disable this listener.

See systemd/systemd#4061 for the upstream status.
