### PR TITLE
cherry-pick: nspawn: R/W support for /sys, and /proc/sys (v231)

### DIFF
--- a/src/nspawn/nspawn-mount.h
+++ b/src/nspawn/nspawn-mount.h
@@ -21,6 +21,17 @@
 
 #include <stdbool.h>
 
+#include "cgroup-util.h"
+
+typedef enum MountSettingsMask {
+        MOUNT_FATAL              = 1 << 0, /* if set, a mount error is considered fatal */
+        MOUNT_USE_USERNS         = 1 << 1, /* if set, mounts are patched considering uid/gid shifts in a user namespace */
+        MOUNT_IN_USERNS          = 1 << 2, /* if set, the mount is executed in the inner child, otherwise in the outer child */
+        MOUNT_APPLY_APIVFS_RO    = 1 << 3, /* if set, /proc/sys, and /sysfs will be mounted read-only, otherwise read-write. */
+        MOUNT_APPLY_APIVFS_NETNS = 1 << 4, /* if set, /proc/sys/net will be mounted read-write.
+                                              Works only if MOUNT_APPLY_APIVFS_RO is also set. */
+} MountSettingsMask;
+
 typedef enum VolatileMode {
         VOLATILE_NO,
         VOLATILE_YES,
@@ -55,8 +66,8 @@ int tmpfs_mount_parse(CustomMount **l, unsigned *n, const char *s);
 
 int custom_mount_compare(const void *a, const void *b);
 
-int mount_all(const char *dest, bool use_userns, bool in_userns, bool use_netns, uid_t uid_shift, uid_t uid_range, const char *selinux_apifs_context);
-int mount_sysfs(const char *dest);
+int mount_all(const char *dest, MountSettingsMask mount_settings, uid_t uid_shift, uid_t uid_range, const char *selinux_apifs_context);
+int mount_sysfs(const char *dest, MountSettingsMask mount_settings);
 
 int mount_cgroups(const char *dest, bool unified_requested, bool userns, uid_t uid_shift, uid_t uid_range, const char *selinux_apifs_context);
 int mount_systemd_cgroup_writable(const char *dest, bool unified_requested);


### PR DESCRIPTION
This cherry-picks the upstream contribution https://github.com/systemd/systemd/pull/4395.
It is needed in rkt to support privileged containers https://github.com/coreos/rkt/issues/3245.

This is the backport for v231 of systemd.