### PR TITLE
nspawn: fix exit code for --help and --version (systemd#4609)

### DIFF
--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -4033,7 +4033,7 @@ int main(int argc, char *argv[]) {
         bool root_device_rw = true, home_device_rw = true, srv_device_rw = true;
         _cleanup_close_ int master = -1, image_fd = -1;
         _cleanup_fdset_free_ FDSet *fds = NULL;
-        int r, n_fd_passed, loop_nr = -1, ret = EXIT_FAILURE;
+        int r, n_fd_passed, loop_nr = -1, ret = EXIT_SUCCESS;
         char veth_name[IFNAMSIZ] = "";
         bool secondary = false, remove_subvol = false;
         pid_t pid = 0;


### PR DESCRIPTION
Commit b006762 inverted the initial exit code which is relevant for --help and
--version without a particular reason.  For these special options, parse_argv()
returns 0 so that our main() immediately skips to the end without adjusting
"ret". Otherwise, if an actual container is being started, ret is set on error
in run(), which still provides the "non-zero exit on error" behaviour.

Fixes https://github.com/systemd/systemd/issues/4605