### PR TITLE
Backport the option to blacklist interfaces

### DIFF
--- a/man/systemd.network.xml
+++ b/man/systemd.network.xml
@@ -212,6 +212,18 @@
           below 1280 (the minimum MTU for IPv6) it will automatically be increased to this value.</para>
         </listitem>
       </varlistentry>
+      <varlistentry>
+        <term><varname>Unmanaged=</varname></term>
+        <listitem>
+          <para>A boolean. When <literal>yes</literal>, no attempts are
+          made to bring up or configure matching links, equivalent to
+          when there are no matching network files. Defaults to
+          <literal>no</literal>.</para>
+          <para>This is useful for preventing later matching network
+          files from interfering with certain interfaces that are fully
+          controlled by other applications.</para>
+        </listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
 

--- a/src/network/networkd-link.c
+++ b/src/network/networkd-link.c
@@ -2485,6 +2485,9 @@ static int link_initialized_and_synced(sd_netlink *rtnl, sd_netlink_message *m,
                 if (r == -ENOENT) {
                         link_enter_unmanaged(link);
                         return 1;
+                } else if (r == 0 && network->unmanaged) {
+                        link_enter_unmanaged(link);
+                        return 0;
                 } else if (r < 0)
                         return r;
 

--- a/src/network/networkd-network-gperf.gperf
+++ b/src/network/networkd-network-gperf.gperf
@@ -28,6 +28,7 @@ Match.KernelCommandLine,                config_parse_net_condition,             
 Match.Architecture,                     config_parse_net_condition,                     CONDITION_ARCHITECTURE,        offsetof(Network, match_arch)
 Link.MACAddress,                        config_parse_hwaddr,                            0,                             offsetof(Network, mac)
 Link.MTUBytes,                          config_parse_iec_size,                          0,                             offsetof(Network, mtu)
+Link.Unmanaged,                         config_parse_bool,                              0,                             offsetof(Network, unmanaged)
 Network.Description,                    config_parse_string,                            0,                             offsetof(Network, description)
 Network.Bridge,                         config_parse_netdev,                            0,                             offsetof(Network, bridge)
 Network.Bond,                           config_parse_netdev,                            0,                             offsetof(Network, bond)

--- a/src/network/networkd-network.h
+++ b/src/network/networkd-network.h
@@ -172,6 +172,7 @@ struct Network {
 
         struct ether_addr *mac;
         unsigned mtu;
+        bool unmanaged;
         uint32_t iaid;
         DUID duid;
 


### PR DESCRIPTION
This backports systemd/systemd@a09dc5467a3d289a53ef3ea87d3b155d8d0551c9 to our v231 branch (sans the conflicty Python 3 tests) and reverts the workaround we had in place.

@coreos/team-os Were there any other use cases for this workaround besides the docker/flannel conflicts?