### PR TITLE
systemd: Disable SELinux permissions checks

### DIFF
--- a/src/core/selinux-access.h
+++ b/src/core/selinux-access.h
@@ -26,20 +26,5 @@
 
 int mac_selinux_generic_access_check(sd_bus_message *message, const char *path, const char *permission, sd_bus_error *error);
 
-#ifdef HAVE_SELINUX
-
-#define mac_selinux_access_check(message, permission, error) \
-        mac_selinux_generic_access_check((message), NULL, (permission), (error))
-
-#define mac_selinux_unit_access_check(unit, message, permission, error) \
-        ({                                                              \
-                Unit *_unit = (unit);                                   \
-                mac_selinux_generic_access_check((message), _unit->source_path ?: _unit->fragment_path, (permission), (error)); \
-        })
-
-#else
-
 #define mac_selinux_access_check(message, permission, error) 0
 #define mac_selinux_unit_access_check(unit, message, permission, error) 0
-
-#endif


### PR DESCRIPTION
We don't care about the interaction between systemd and SELinux policy, so
let's just disable these checks rather than having to incorporate policy
support. This has no impact on our SELinux use-case, which is purely intended
to limit containers and not anything running directly on the host.