### PR TITLE
nspawn: split down SYSTEMD_NSPAWN_SHARE_SYSTEM

### DIFF
--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -1061,7 +1061,8 @@ static int parse_argv(int argc, char *argv[]) {
         parse_share_ns_env("SYSTEMD_NSPAWN_SHARE_NS_UTS", CLONE_NEWUTS);
         parse_share_ns_env("SYSTEMD_NSPAWN_SHARE_SYSTEM", CLONE_NEWIPC|CLONE_NEWPID|CLONE_NEWUTS);
 
-        if (arg_clone_ns_flags != (CLONE_NEWIPC|CLONE_NEWPID|CLONE_NEWUTS)) {
+        if (!(arg_clone_ns_flags & CLONE_NEWPID) ||
+            !(arg_clone_ns_flags & CLONE_NEWUTS)) {
                 arg_register = false;
                 if (arg_start_mode != START_PID1) {
                         log_error("--boot cannot be used without namespacing.");


### PR DESCRIPTION
This is a backport of two upstream-v232 commits to coreos-v231, namely:
 * https://github.com/systemd/systemd/pull/4023/commits/428ce06b680c11f494fa2332d1bcec1cf2ed66b2
 * https://github.com/systemd/systemd/pull/4180/commits/4d3a5fe6f8bb4fef8cd2a271e683fcc90b783e91

It is a pre-requisite for https://github.com/coreos/rkt/issues/3291.