### PR TITLE
backport: "nspawn: let's mount(/tmp) inside the user namespace (#4340)"

### DIFF
--- a/src/nspawn/nspawn-mount.c
+++ b/src/nspawn/nspawn-mount.c
@@ -369,7 +369,10 @@ int mount_all(const char *dest,
 
                 o = mount_table[k].options;
                 if (streq_ptr(mount_table[k].type, "tmpfs")) {
-                        r = tmpfs_patch_options(o, use_userns, uid_shift, uid_range, selinux_apifs_context, &options);
+                        if (in_userns)
+                                r = tmpfs_patch_options(o, use_userns, 0, uid_range, selinux_apifs_context, &options);
+                        else
+                                r = tmpfs_patch_options(o, use_userns, uid_shift, uid_range, selinux_apifs_context, &options);
                         if (r < 0)
                                 return log_oom();
                         if (r > 0)


### PR DESCRIPTION
https://github.com/coreos/systemd/pull/71 introduced a regression in coreos/systemd `systemd-nspawn` when user namespaces are enabled using the `--private-users` option. Upstream is not affected. coreos/systemd was missing another backport commit, namely https://github.com/systemd/systemd/commit/8492849ee567c4657d6ac6587ed9536857624b4c.

This was found in the functional tests with `USER_NS` enabled in rkt when bumping the "coreos stage1" image: https://github.com/coreos/rkt/pull/3535.

That also unfortunately means that in CoreOS 1284.2.0 the `systemd-nspawn --private-users ...` functionality is broken failing with a failed tmpfs mount error like this (strace output):

```
$ sudo strace systemd-nspawn --private-users ...
...
[pid 27787] mount("tmpfs", "/tmp", "tmpfs", MS_STRICTATIME, "mode=1777,uid=1174339584,gid=1174339584") = -1 EINVAL (Invalid argument)
```

Note that when using "regular" systemd-nspawn without user namespaces enabled, there is no regression.

/cc @crawford Can you advice how many use cases for `systemd-nspawn --private-users` are out there? It would be great if we could land this in the next Alpha release this week.

Thanks in advance!

/cc @lucab