### PR TITLE
Address v233 behavior changes that break things

### DIFF
--- a/src/nspawn/nspawn.c
+++ b/src/nspawn/nspawn.c
@@ -1357,23 +1357,6 @@ static int setup_resolv_conf(const char *dest) {
                 return 0;
         }
 
-        if (access("/usr/lib/systemd/resolv.conf", F_OK) >= 0 &&
-            resolved_running() > 0) {
-
-                /* resolved is enabled on the host. In this, case bind mount its static resolv.conf file into the
-                 * container, so that the container can use the host's resolver. Given that network namespacing is
-                 * disabled it's only natural of the container also uses the host's resolver. It also has the big
-                 * advantage that the container will be able to follow the host's DNS server configuration changes
-                 * transparently. */
-
-                if (found == 0) /* missing? */
-                        (void) touch(resolved);
-
-                r = mount_verbose(LOG_DEBUG, "/usr/lib/systemd/resolv.conf", resolved, NULL, MS_BIND, NULL);
-                if (r >= 0)
-                        return mount_verbose(LOG_ERR, NULL, resolved, NULL, MS_BIND|MS_REMOUNT|MS_RDONLY|MS_NOSUID|MS_NODEV, NULL);
-        }
-
         /* If that didn't work, let's copy the file */
         r = copy_file("/etc/resolv.conf", where, O_TRUNC|O_NOFOLLOW, 0644, 0, COPY_REFLINK);
         if (r < 0) {

--- a/src/resolve/resolved-manager.c
+++ b/src/resolve/resolved-manager.c
@@ -547,7 +547,7 @@ int manager_new(Manager **ret) {
         m->hostname_fd = -1;
 
         m->llmnr_support = RESOLVE_SUPPORT_YES;
-        m->mdns_support = RESOLVE_SUPPORT_YES;
+        m->mdns_support = RESOLVE_SUPPORT_NO;
         m->dnssec_mode = DEFAULT_DNSSEC_MODE;
         m->enable_cache = true;
         m->dns_stub_listener_mode = DNS_STUB_LISTENER_UDP;


### PR DESCRIPTION
The nspawn change attempted to use the local DNS stub resolver without considering that its listener is optional.  Since we have it disabled by default, nspawn DNS would always be broken.  Just drop the stub resolver logic and always use `/etc/resolv.conf` (which the user can still point at the stub resolver).

The mDNS change is just another new service listening on the network that can conflict with services the user wants to run.  There is a PR at systemd/systemd#5531 to make it optional as with the DNS listener.  For now, revert to the previous behavior of leaving it disabled.