### PR TITLE
[v233] core: evaluate presets after generators have run

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -1798,17 +1798,9 @@ int main(int argc, char *argv[]) {
                 if (prctl(PR_SET_CHILD_SUBREAPER, 1) < 0)
                         log_warning_errno(errno, "Failed to make us a subreaper: %m");
 
-        if (arg_system) {
+        if (arg_system)
+                /* Bump up RLIMIT_NOFILE for systemd itself */
                 (void) bump_rlimit_nofile(&saved_rlimit_nofile);
-
-                if (empty_etc) {
-                        r = unit_file_preset_all(UNIT_FILE_SYSTEM, 0, NULL, UNIT_FILE_PRESET_ENABLE_ONLY, NULL, 0);
-                        if (r < 0)
-                                log_full_errno(r == -EEXIST ? LOG_NOTICE : LOG_WARNING, r, "Failed to populate /etc with preset unit settings, ignoring: %m");
-                        else
-                                log_info("Populated /etc with preset unit settings.");
-                }
-        }
 
         r = manager_new(arg_system ? UNIT_FILE_SYSTEM : UNIT_FILE_USER, arg_action == ACTION_TEST, &m);
         if (r < 0) {

--- a/src/core/manager.c
+++ b/src/core/manager.c
@@ -1283,6 +1283,14 @@ int manager_startup(Manager *m, FILE *serialization, FDSet *fds) {
         if (r < 0)
                 return r;
 
+        if (m->first_boot && m->unit_file_scope == UNIT_FILE_SYSTEM) {
+                q = unit_file_preset_all(UNIT_FILE_SYSTEM, 0, NULL, UNIT_FILE_PRESET_ENABLE_ONLY, NULL, 0);
+                if (q < 0)
+                        log_full_errno(q == -EEXIST ? LOG_NOTICE : LOG_WARNING, q, "Failed to populate /etc with preset unit settings, ignoring: %m");
+                else
+                        log_info("Populated /etc with preset unit settings.");
+        }
+
         lookup_paths_reduce(&m->lookup_paths);
         manager_build_unit_path_cache(m);
 


### PR DESCRIPTION
This is a backport of https://github.com/systemd/systemd/commit/28dd66ecfce743b1ea9046c7bb501e0fcaeff724 to v233.

---

This commit moves the first-boot system preset-settings evaluation out
of main and into the manager startup logic itself. Notably, it reverses
the order between generators and presets evaluation, so that any changes
performed by first-boot generators are taken into the account by presets
logic.

After this change, units created by a generator can be enabled as part
of a preset.