### PR TITLE
Backport upstream fixes to v237

### DIFF
--- a/src/basic/gcrypt-util.c
+++ b/src/basic/gcrypt-util.c
@@ -42,7 +42,7 @@ void initialize_libgcrypt(bool secmem) {
 }
 
 int string_hashsum(const char *s, size_t len, int md_algorithm, char **out) {
-        gcry_md_hd_t md = NULL;
+        _cleanup_(gcry_md_closep) gcry_md_hd_t md = NULL;
         size_t hash_size;
         void *hash;
         char *enc;

--- a/src/basic/gcrypt-util.h
+++ b/src/basic/gcrypt-util.h
@@ -20,6 +20,8 @@
   along with systemd; If not, see <http://www.gnu.org/licenses/>.
 ***/
 
+#pragma once
+
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -27,8 +29,12 @@
 #if HAVE_GCRYPT
 #include <gcrypt.h>
 
+#include "macro.h"
+
 void initialize_libgcrypt(bool secmem);
 int string_hashsum(const char *s, size_t len, int md_algorithm, char **out);
+
+DEFINE_TRIVIAL_CLEANUP_FUNC(gcry_md_hd_t, gcry_md_close);
 #endif
 
 static inline int string_hashsum_sha224(const char *s, size_t len, char **out) {

--- a/src/basic/process-util.c
+++ b/src/basic/process-util.c
@@ -1137,7 +1137,7 @@ pid_t getpid_cached(void) {
         case CACHED_PID_UNSET: { /* Not initialized yet, then do so now */
                 pid_t new_pid;
 
-                new_pid = getpid();
+                new_pid = raw_getpid();
 
                 if (__register_atfork(NULL, NULL, reset_cached_pid, __dso_handle) != 0) {
                         /* OOM? Let's try again later */
@@ -1150,7 +1150,7 @@ pid_t getpid_cached(void) {
         }
 
         case CACHED_PID_BUSY: /* Somebody else is currently initializing */
-                return getpid();
+                return raw_getpid();
 
         default: /* Properly initialized */
                 return current_value;

--- a/src/network/networkd-manager.c
+++ b/src/network/networkd-manager.c
@@ -1380,7 +1380,7 @@ static void dhcp6_prefixes_hash_func(const void *p, struct siphash *state) {
 static int dhcp6_prefixes_compare_func(const void *_a, const void *_b) {
         const struct in6_addr *a = _a, *b = _b;
 
-        return memcmp(&a, &b, sizeof(*a));
+        return memcmp(a, b, sizeof(*a));
 }
 
 static const struct hash_ops dhcp6_prefixes_hash_ops = {


### PR DESCRIPTION
Backport some fixes that came in after 237 was cut. These can be dropped in 238 as they are already in upstream master.

99bdf7e  may not actually do anything with our glibc 2.23 but if https://github.com/coreos/coreos-overlay/pull/2886 merges we'll want it.

Tested locally with a full kola qemu run