### PR TITLE
core: when reloading, delay any actions on journal and dbus connections

### DIFF
--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -2502,8 +2502,11 @@ void unit_notify(Unit *u, UnitActiveState os, UnitActiveState ns, bool reload_su
                 }
         }
 
-        manager_recheck_journal(m);
-        manager_recheck_dbus(m);
+        if (!MANAGER_IS_RELOADING(u->manager)) {
+                manager_recheck_journal(m);
+                manager_recheck_dbus(m);
+        }
+
         unit_trigger_notify(u);
 
         if (!MANAGER_IS_RELOADING(u->manager)) {


### PR DESCRIPTION
This is a backport of https://github.com/systemd/systemd/pull/8473 from upstream master in order to fix a regression introduced with v238.

Ref https://github.com/coreos/go-systemd/issues/255
Ref https://github.com/systemd/systemd/issues/8414
Ref https://bugzilla.redhat.com/show_bug.cgi?id=1554578