### PR TITLE
Backport to v237: socket-util: fix getpeergroups() assert(fd)

### DIFF
--- a/src/basic/socket-util.c
+++ b/src/basic/socket-util.c
@@ -1008,7 +1008,7 @@ int getpeergroups(int fd, gid_t **ret) {
         socklen_t n = sizeof(gid_t) * 64;
         _cleanup_free_ gid_t *d = NULL;
 
-        assert(fd);
+        assert(fd >= 0);
         assert(ret);
 
         for (;;) {


### PR DESCRIPTION
Backport to v237 of https://github.com/systemd/systemd/commit/75f40779607ea79f20441c7fb46744d04ee2c7ae, to solve poweroff problems in https://groups.google.com/forum/#!topic/coreos-user/YcGkRHU9SvQ.