### PR TITLE
udev/net-id: Fix check for address to keep interface names stable

### DIFF
--- a/src/udev/udev-builtin-net_id.c
+++ b/src/udev/udev-builtin-net_id.c
@@ -297,7 +297,7 @@ static int dev_pci_slot(struct udev_device *dev, struct netnames *names) {
                 if (snprintf_ok(str, sizeof str, "%s/%s/address", slots, dent->d_name) &&
                     read_one_line_file(str, &address) >= 0)
                         /* match slot address with device by stripping the function */
-                        if (streq(address, udev_device_get_sysname(names->pcidev)))
+                        if (startswith(udev_device_get_sysname(names->pcidev), address))
                                 hotplug_slot = i;
 
                 if (hotplug_slot > 0)


### PR DESCRIPTION
Backport https://github.com/systemd/systemd/commit/8eebb6a9e5e74ec0ef40902e2da53d24559b94a4 to fix https://github.com/coreos/bugs/issues/2437.