### PR TITLE
Rebase v238 patches onto v239

### DIFF
--- a/man/systemd-system.conf.xml
+++ b/man/systemd-system.conf.xml
@@ -339,8 +339,7 @@
         <listitem><para>Configure the default value for the per-unit <varname>TasksMax=</varname> setting. See
         <citerefentry><refentrytitle>systemd.resource-control</refentrytitle><manvolnum>5</manvolnum></citerefentry>
         for details. This setting applies to all unit types that support resource control settings, with the exception
-        of slice units. Defaults to 15%, which equals 4915 with the kernel's defaults on the host, but might be smaller
-        in OS containers.</para></listitem>
+        of slice units. Defaults to 100%.</para></listitem>
       </varlistentry>
 
       <varlistentry>

--- a/man/systemd-update-done.service.xml
+++ b/man/systemd-update-done.service.xml
@@ -51,7 +51,7 @@
     <varname>ConditionNeedsUpdate=</varname> (see
     <citerefentry><refentrytitle>systemd.unit</refentrytitle><manvolnum>5</manvolnum></citerefentry>)
     condition to make sure to run when <filename>/etc</filename> or
-    <filename>/var</filename> are older than <filename>/usr</filename>
+    <filename>/var</filename> aren't the same age as <filename>/usr</filename>
     according to the modification times of the files described above.
     This requires that updates to <filename>/usr</filename> are always
     followed by an update of the modification time of

--- a/man/systemd.unit.xml
+++ b/man/systemd.unit.xml
@@ -1143,7 +1143,7 @@
         inverting the condition). This condition may be used to
         conditionalize units on whether the specified directory
         requires an update because <filename>/usr</filename>'s
-        modification time is newer than the stamp file
+        modification time differs from that of the stamp file
         <filename>.updated</filename> in the specified directory. This
         is useful to implement offline updates of the vendor operating
         system resources in <filename>/usr</filename> that require

--- a/src/basic/cgroup-util.h
+++ b/src/basic/cgroup-util.h
@@ -100,7 +100,7 @@ static inline bool CGROUP_BLKIO_WEIGHT_IS_OK(uint64_t x) {
 }
 
 /* Default resource limits */
-#define DEFAULT_TASKS_MAX_PERCENTAGE            15U /* 15% of PIDs, 4915 on default settings */
+#define DEFAULT_TASKS_MAX_PERCENTAGE            100U /* 100% of PIDs */
 #define DEFAULT_USER_TASKS_MAX_PERCENTAGE       33U /* 33% of PIDs, 10813 on default settings */
 
 typedef enum CGroupUnified {

--- a/src/core/selinux-access.h
+++ b/src/core/selinux-access.h
@@ -12,7 +12,7 @@
 
 int mac_selinux_generic_access_check(sd_bus_message *message, const char *path, const char *permission, sd_bus_error *error);
 
-#if HAVE_SELINUX
+#if 0
 
 #define mac_selinux_access_check(message, permission, error) \
         mac_selinux_generic_access_check((message), NULL, (permission), (error))

--- a/src/core/system.conf.in
+++ b/src/core/system.conf.in
@@ -45,7 +45,7 @@
 #DefaultBlockIOAccounting=no
 #DefaultMemoryAccounting=@MEMORY_ACCOUNTING_DEFAULT@
 #DefaultTasksAccounting=yes
-#DefaultTasksMax=15%
+#DefaultTasksMax=100%
 #DefaultLimitCPU=
 #DefaultLimitFSIZE=
 #DefaultLimitDATA=

--- a/src/network/networkd-network.c
+++ b/src/network/networkd-network.c
@@ -235,6 +235,8 @@ static int network_load_one(Manager *manager, const char *filename) {
 
         network->link_local = ADDRESS_FAMILY_IPV6;
 
+        network->ip_forward = _ADDRESS_FAMILY_BOOLEAN_INVALID;
+
         network->ipv6_privacy_extensions = IPV6_PRIVACY_EXTENSIONS_NO;
         network->ipv6_accept_ra = -1;
         network->ipv6_dad_transmits = -1;

--- a/src/network/wait-online/manager.c
+++ b/src/network/wait-online/manager.c
@@ -57,13 +57,13 @@ bool manager_all_configured(Manager *m) {
                 if (!l->state) {
                         log_debug("link %s has not yet been processed by udev",
                                   l->ifname);
-                        return false;
+                        continue;
                 }
 
                 if (STR_IN_SET(l->state, "configuring", "pending")) {
                         log_debug("link %s is being processed by networkd",
                                   l->ifname);
-                        return false;
+                        continue;
                 }
 
                 if (l->operational_state &&

--- a/src/shared/condition.c
+++ b/src/shared/condition.c
@@ -447,7 +447,7 @@ static int condition_test_needs_update(Condition *c) {
          * First, compare seconds as they are always accurate...
          */
         if (usr.st_mtim.tv_sec != other.st_mtim.tv_sec)
-                return usr.st_mtim.tv_sec > other.st_mtim.tv_sec;
+                return true;
 
         /*
          * ...then compare nanoseconds.
@@ -480,7 +480,7 @@ static int condition_test_needs_update(Condition *c) {
                 timespec_store(&other.st_mtim, timestamp);
         }
 
-        return usr.st_mtim.tv_nsec > other.st_mtim.tv_nsec;
+        return usr.st_mtim.tv_nsec != other.st_mtim.tv_nsec;
 }
 
 static int condition_test_first_boot(Condition *c) {


### PR DESCRIPTION
This dropped 4cd49cc7a233bcb109427042a087d7c4ecaff6ed due to no longer generating images in OCI format.