### PR TITLE
namespace: make MountFlags=shared work again

### DIFF
--- a/src/core/execute.c
+++ b/src/core/execute.c
@@ -1839,7 +1839,7 @@ static bool exec_needs_mount_namespace(
         if (context->n_temporary_filesystems > 0)
                 return true;
 
-        if (context->mount_flags != 0)
+        if (!IN_SET(context->mount_flags, 0, MS_SHARED))
                 return true;
 
         if (context->private_tmp && runtime && (runtime->tmp_dir || runtime->var_tmp_dir))
@@ -2434,6 +2434,9 @@ static int apply_mount_namespace(
                 };
         else
                 ns_info = (NamespaceInfo) {};
+
+        if (context->mount_flags == MS_SHARED)
+                log_unit_debug(u, "shared mount propagation hidden by other fs namespacing unit settings: ignoring");
 
         r = setup_namespace(root_dir, root_image,
                             &ns_info, context->read_write_paths,


### PR DESCRIPTION
Backport 37ed15d7edaf59a1fc7c9e3552cd93a83f3814ef to fix coreos/bugs#2579.